### PR TITLE
Fix max height exploit

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/translation/TranslationTask.java
@@ -145,7 +145,7 @@ public class TranslationTask extends AsyncTask {
                 if (craft.getW().getBlockTypeIdAt(middle.getX(),testY,middle.getZ()) != 0)
                     break;
             }
-            if (minY - testY > craft.getType().getMaxHeightAboveGround(world)) {
+            if (maxY - testY > craft.getType().getMaxHeightAboveGround(world)) {
                 dy = Math.min(dy,-1);
             }
         }


### PR DESCRIPTION
This PR fixes an exploit where players could add blocks to the bottom of a craft to increase the height it could fly at.

<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request acomplishes

<!-- Delete if not aplicable -->
<!-- If you're fixing an issue, make sure to prefix the linked issue with "fixes". -->
### Related issues:
- 

### Checklist
- [ ] Unit tests <!-- if implementing API utilities, otherwise delete -->
- [ ] Proper internationalization
- [ ] Compiled/tested
